### PR TITLE
:construction: (RequestCard) Hook up upvoteProductRequestHook to comp

### DIFF
--- a/src/components/content/RequestCard.tsx
+++ b/src/components/content/RequestCard.tsx
@@ -13,48 +13,37 @@ import styles from './RequestCard.module.scss';
 
 interface RequestCardProps {
   request: ProductRequest;
+  upvoteProductRequest: (requestId: number) => void;
 }
 
-function RequestCard({ request }: RequestCardProps) {
-  // Returns the number of comments in a product request, including replies.
-  const getCommentCount = (): number => {
-    let commentCount: number = 0;
-
-    if (request.comments) {
-      commentCount = request.comments.length;
-      request.comments.forEach((comment) => {
-        if (comment.replies) {
-          commentCount += comment.replies.length;
-        }
-      });
-    }
-
-    return commentCount;
-  };
-
+function RequestCard({ request, upvoteProductRequest }: RequestCardProps) {
   return (
     <Card className={styles.requestCard}>
-      <UpvoteButton upvotes={request.upvotes} />
+      <UpvoteButton
+        upvotes={request.upvotes}
+        upvoteProductRequest={() => upvoteProductRequest(request.id)}
+      />
       <RequestDetails
         title={request.title}
         description={request.description}
         category={request.category}
       />
-      <Comments commentCount={getCommentCount()} />
+      <Comments commentCount={(request.comments || []).length} />
     </Card>
   );
 }
 
 interface UpvoteButtonProps {
   upvotes: number;
+  upvoteProductRequest: () => void;
 }
 
-function UpvoteButton({ upvotes }: UpvoteButtonProps) {
+function UpvoteButton({ upvotes, upvoteProductRequest }: UpvoteButtonProps) {
   return (
-    <div className={styles.upvotes}>
+    <button className={styles.upvotes} onClick={upvoteProductRequest}>
       <img src={ArrowUp} />
       {upvotes}
-    </div>
+    </button>
   );
 }
 


### PR DESCRIPTION
The `getCommentCount` function created data which would never be used by this component. 

Additionally, a shortcut to calculating commentCount was used. Props a recalculated on re-renders and so a function was not necessary in this context. Based on the current interface design, the `comments` property is optional and so in accessing the property a fallback empty list was provided to simplify the logic.