### PR TITLE
:construction: (category_filters) Implement initial category filters

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,6 +16,7 @@ interface AppProps {}
 function App({}: AppProps) {
   const {
     feedback,
+    categoryFilter,
     upvoteProductRequest,
     addComment,
     replyToComment,
@@ -35,7 +36,10 @@ function App({}: AppProps) {
             <h1>Frontend Mentor</h1>
             <h2>Feedback Board</h2>
           </Rainbox>
-          <FilterBox />
+          <FilterBox
+            currentFilter={categoryFilter}
+            filterByCategory={filterByCategory}
+          />
           <Roadmap />
         </Stack>
         <Stack>

--- a/src/components/PillButton.tsx
+++ b/src/components/PillButton.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { MouseEventHandler } from 'react';
 
 import style from './PillButton.module.scss';
 
@@ -6,10 +6,14 @@ interface PillButtonProps {
   text?: string;
   active: boolean;
   children?: React.ReactNode;
+  onClick: () => void;
 }
-function PillButton({ text, active, children }: PillButtonProps) {
+function PillButton({ text, active, children, onClick }: PillButtonProps) {
   return (
-    <button className={`${style.pill_button} ${active ? style.active : ''}`}>
+    <button
+      onClick={() => onClick()}
+      className={`${style.pill_button} ${active ? style.active : ''}`}
+    >
       {text || children}
     </button>
   );

--- a/src/components/content/FilterBox.tsx
+++ b/src/components/content/FilterBox.tsx
@@ -1,25 +1,35 @@
-import React from 'react';
+import React, { useState } from 'react';
+import {
+  ProductRequestCategory,
+  ProductRequestCategoryFilters,
+} from '../../interfaces/productRequest.interface';
 import Card from '../Card';
 import PillButton from '../PillButton';
 
 import styles from './FilterBox.module.scss';
 
-type Filter = [string, boolean];
+type Filter = [string, ProductRequestCategory | 'all'];
 const filters: Filter[] = [
-  ['All', true],
-  ['UI', false],
-  ['UX', false],
-  ['Bug', false],
-  ['Enhancement', false],
-  ['Feature', false],
+  ['All', 'all'],
+  ['Bug', ProductRequestCategory.Bug],
+  ['Enhancement', ProductRequestCategory.Enhancement],
+  ['Feature', ProductRequestCategory.Feature],
 ];
 
-interface FilterBoxProps {}
-function FilterBox({}: FilterBoxProps) {
+interface FilterBoxProps {
+  currentFilter: ProductRequestCategoryFilters;
+  filterByCategory: (categoryFilter: ProductRequestCategoryFilters) => void;
+}
+function FilterBox({ currentFilter, filterByCategory }: FilterBoxProps) {
   return (
     <Card className={styles.filter_box}>
-      {filters.map(([text, active]) => (
-        <PillButton key={text} text={text} active={active} />
+      {filters.map(([text, categoryFilter]) => (
+        <PillButton
+          key={categoryFilter}
+          text={text}
+          active={currentFilter == categoryFilter}
+          onClick={() => filterByCategory(categoryFilter)}
+        />
       ))}
     </Card>
   );

--- a/src/components/content/FilterBox.tsx
+++ b/src/components/content/FilterBox.tsx
@@ -8,7 +8,7 @@ import PillButton from '../PillButton';
 
 import styles from './FilterBox.module.scss';
 
-type Filter = [string, ProductRequestCategory | 'all'];
+type Filter = [string, ProductRequestCategoryFilters];
 const filters: Filter[] = [
   ['All', 'all'],
   ['Bug', ProductRequestCategory.Bug],

--- a/src/components/content/OptionBanner.tsx
+++ b/src/components/content/OptionBanner.tsx
@@ -37,7 +37,9 @@ function OptionsDropdown({}: OptionsDropdownProps) {
       <span>Sort by :</span>
       <select name="sort_options" className={styles.dropdown__select}>
         {Object.entries(SortOrder).map(([key, value]) => (
-          <option value={key}>{value}</option>
+          <option key={key} value={key}>
+            {value}
+          </option>
         ))}
       </select>
       <div className={styles.dropdown__downarrow}></div>

--- a/src/components/content/RequestCard.tsx
+++ b/src/components/content/RequestCard.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import type {
   ProductRequest,
   ProductRequestCategory,
-} from 'src/interfaces/productRequest.interface';
+} from '../../interfaces/productRequest.interface';
 import Card from '../Card';
 import PillButton from '../PillButton';
 import ArrowUp from '../../../public/assets/shared/icon-arrow-up.svg';
@@ -84,7 +84,11 @@ function RequestDetails({ title, description, category }: RequestDetailsProps) {
     <div className={styles.requestDetails}>
       <h3 className={styles.requestDetails__title}>{title}</h3>
       <p className={styles.requestDetails__description}>{description}</p>
-      <PillButton text={formatCategory(category)} active={false} />
+      <PillButton
+        onClick={() => null}
+        text={formatCategory(category)}
+        active={false}
+      />
     </div>
   );
 }

--- a/src/hooks/useProductFeedback.ts
+++ b/src/hooks/useProductFeedback.ts
@@ -4,11 +4,14 @@ import type {
   ProductRequest,
   Reply,
   ProductRequestCategory,
+  ProductRequestCategoryFilters,
 } from '../interfaces/productRequest.interface';
 import type { User } from '../interfaces/user.interface';
 
 export function useProductFeedback(data: ProductFeedback) {
   const [feedback, setFeedback] = useState<ProductFeedback>(data);
+  const [categoryFilter, setCategoryFilter] =
+    useState<ProductRequestCategoryFilters>('all');
 
   const createProductRequest = (productRequest: ProductRequest): void => {
     const requestsCopy: ProductRequest[] = [...feedback.productRequests];
@@ -239,17 +242,25 @@ export function useProductFeedback(data: ProductFeedback) {
     return commentCount;
   };
 
-  const filterByCategory = (category: ProductRequestCategory): void => {
-    let requestsCopy: ProductRequest[] = [...feedback.productRequests];
-    let filtered: ProductRequest[] = requestsCopy.filter(
-      (request) => request.category === category,
-    );
+  const filterByCategory = (category: ProductRequestCategoryFilters): void => {
+    if (category === 'all')
+      setFeedback({
+        ...feedback,
+        productRequests: data.productRequests,
+      });
+    else {
+      let filtered: ProductRequest[] = data.productRequests.filter(
+        (request) => request.category === category,
+      );
 
-    setFeedback({ ...feedback, productRequests: filtered });
+      setFeedback({ ...feedback, productRequests: filtered });
+    }
+    setCategoryFilter(category);
   };
 
   return {
     feedback,
+    categoryFilter,
     upvoteProductRequest,
     addComment,
     replyToComment,

--- a/src/interfaces/productRequest.interface.ts
+++ b/src/interfaces/productRequest.interface.ts
@@ -16,6 +16,8 @@ export enum ProductRequestCategory {
   Bug = 'bug',
 }
 
+export type ProductRequestCategoryFilters = ProductRequestCategory | 'all';
+
 export enum ProductRequestStatus {
   Live = 'live',
   InProgress = 'in-progress',


### PR DESCRIPTION
`filterByCategory` had a bug whereby it was filtering down the list without restoring the full list first. This resulted in the list being filtered down to 0 items upon hitting a second filter.

Note: `Array.prototype.filter` creates a copy by default.